### PR TITLE
ThreatScoreMinimum

### DIFF
--- a/Data/SpawnGroups.sbc
+++ b/Data/SpawnGroups.sbc
@@ -46,7 +46,8 @@
 
         [UseThreatLevelCheck:true]
         [ThreatLevelCheckRange:10000]
-        [ThreatScoreMaximum:500]
+        [ThreatScoreMinimum:200]
+        [ThreatScoreMaximum:750]
 
       </Description>
       <IsPirate>true</IsPirate>


### PR DESCRIPTION
There wasn't a threatscoreminimum value defined for spawn group RobotRaiderPods-SpawnGroup-RaiderPod-Easy causing them to spawn way to early in some casing, and as a result wiping out newly started bases/players